### PR TITLE
add Command() for measuring a subprocess

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -1,0 +1,95 @@
+package perf
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+// command implements shared functionality between Command() and
+// (*Group).Command().
+func command(cmd *exec.Cmd, setupCounters func() error) error {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Ptrace = true
+
+	err := cmd.Start()
+	if err != nil {
+		return err
+	}
+
+	state, err := cmd.Process.Wait()
+	if err != nil {
+		// For good measure to avoid leaking a process.
+		_ = cmd.Process.Kill()
+		return err
+	}
+	if state.Sys().(syscall.WaitStatus).TrapCause() == -1 {
+		// For good measure to avoid leaking a process.
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return fmt.Errorf("tracee did not trap as expected")
+	}
+
+	// Note unusual error flow - if this fails, we still need to detach from
+	// the process and wait on it.
+	errCounters := setupCounters()
+
+	err = syscall.PtraceDetach(cmd.Process.Pid)
+	if err != nil {
+		// For good measure to avoid leaking a process.
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return err
+	}
+
+	err = cmd.Wait()
+	// Note unusual error flow - it's necessary need to detach and wait to
+	// avoid leaking a process, but if there was an error setting up the
+	// counters, this is what the caller needs to know about.
+	if errCounters != nil {
+		return errCounters
+	}
+	return err
+}
+
+// Command invokes the given exec.Cmd and measures the given counter,
+// analogously to Measure().
+func Command(a *Attr, cmd *exec.Cmd, cpu int, event *Event) (Count, error) {
+	var event2 *Event
+	err := command(cmd, func() (err2 error) {
+		event2, err2 = Open(a, cmd.Process.Pid, cpu, event)
+		if err2 != nil {
+			event2.Enable()
+		}
+
+		return err2
+	})
+	if err != nil {
+		return Count{}, err
+	}
+	defer event2.Close()
+
+	return event2.ReadCount()
+}
+
+// Command invokes the given exec.Cmd and measures the given counter,
+// analogously to MeasureGroup().
+func (g *Group) Command(cmd *exec.Cmd, cpu int) (GroupCount, error) {
+	var event2 *Event
+	err := command(cmd, func() (err2 error) {
+		event2, err2 = g.Open(cmd.Process.Pid, cpu)
+		if err2 != nil {
+			event2.Enable()
+		}
+
+		return err2
+	})
+	if err != nil {
+		return GroupCount{}, err
+	}
+	defer event2.Close()
+
+	return event2.ReadGroupCount()
+}

--- a/exec.go
+++ b/exec.go
@@ -61,10 +61,10 @@ func Command(a *Attr, cmd *exec.Cmd, cpu int, event *Event) (Count, error) {
 	err := command(cmd, func() (err2 error) {
 		event2, err2 = Open(a, cmd.Process.Pid, cpu, event)
 		if err2 != nil {
-			event2.Enable()
+			return err2
 		}
 
-		return err2
+		return event2.Enable()
 	})
 	if err != nil {
 		return Count{}, err
@@ -81,10 +81,10 @@ func (g *Group) Command(cmd *exec.Cmd, cpu int) (GroupCount, error) {
 	err := command(cmd, func() (err2 error) {
 		event2, err2 = g.Open(cmd.Process.Pid, cpu)
 		if err2 != nil {
-			event2.Enable()
+			return err2
 		}
 
-		return err2
+		return event2.Enable()
 	})
 	if err != nil {
 		return GroupCount{}, err

--- a/exec_test.go
+++ b/exec_test.go
@@ -42,9 +42,9 @@ func TestCommandGroup(t *testing.T) {
 		Running: true,
 		ID:      true,
 	}
-	g.Add(perf.Instructions, perf.CPUCycles)
 	g.Options.ExcludeKernel = true
 	g.Options.ExcludeHypervisor = true
+	g.Add(perf.Instructions, perf.CPUCycles)
 
 	counts, err := g.Command(cmd, perf.AnyCPU)
 	if err != nil {

--- a/exec_test.go
+++ b/exec_test.go
@@ -1,0 +1,61 @@
+package perf_test
+
+import (
+	"os/exec"
+	"testing"
+
+	"acln.ro/perf"
+)
+
+func TestCommand(t *testing.T) {
+	cmd := exec.Command("echo", "hello world")
+
+	fa := &perf.Attr{
+		CountFormat: perf.CountFormat{
+			Running: true,
+			ID:      true,
+		},
+	}
+	perf.Instructions.Configure(fa)
+	fa.Options.ExcludeKernel = true
+	fa.Options.ExcludeHypervisor = true
+
+	count, err := perf.Command(fa, cmd, perf.AnyCPU, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("count = %v", count.Value)
+
+	// A primitive test to ensure the counter measured something, since we
+	// don't know the "correct" value.
+	if count.Value < 1000 {
+		t.Fatal("counter read less than 1000 - should be > 1M")
+	}
+}
+
+func TestCommandGroup(t *testing.T) {
+	cmd := exec.Command("echo", "hello world")
+
+	var g perf.Group
+	g.CountFormat = perf.CountFormat{
+		Running: true,
+		ID:      true,
+	}
+	g.Add(perf.Instructions, perf.CPUCycles)
+	g.Options.ExcludeKernel = true
+	g.Options.ExcludeHypervisor = true
+
+	counts, err := g.Command(cmd, perf.AnyCPU)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("counts:", counts)
+
+	// A primitive test to ensure the counter measured something, since we
+	// don't know the "correct" value.
+	if counts.Values[0].Value < 1000 || counts.Values[1].Value < 1000 {
+		t.Fatal("counter read less than 1000 - should be > 1M")
+	}
+}


### PR DESCRIPTION
This PR adds a `func Command(a *Attr, cmd *exec.Cmd, cpu int, event *Event)
(Count, error)`, useful to measure counters for a given subprocess, expressed as
an `exec.Cmd`. There is also the analogous function `(*Group).Command`.

See discussion in https://github.com/acln0/perf/issues/3.

The ptrace trickery is required in order to prevent the process under
measurement from doing any work before the counters are setup.

I've made a best attempt to handle the error cases and avoid leaking resources,
but this is untested.

Fixes #3.