### PR TITLE
Avoid returning volatile ring-buffer memory

### DIFF
--- a/perf.go
+++ b/perf.go
@@ -92,6 +92,11 @@ type Event struct {
 	// pollresp receives responses from the poll goroutine associated
 	// with the ring, back to ReadRawRecord.
 	pollresp chan pollresp
+
+	// recordBuffer is used as storage for records returned by ReadRecord
+	// and ReadRawRecord. This means memory for records returned from those
+	// methods will be overwritten by successive calls.
+	recordBuffer []byte
 }
 
 // Open opens the event configured by attr.


### PR DESCRIPTION
Disclaimer: This patch contains some debugging code (fprintf) and some not-so-necessary changes to the Record interface. Feel free to send a new PR to solve the problems outlined here in a way that better suits your vision.

Issue 1

`readRawRecordNonblock` returns a slice that uses the ring-buffer memory as the backing-store. This means a returned record can be overwritten by the kernel at any time, given that the kernel writes records fast enough. That's because this method advances the tail pointer, making the returned memory available to the kernel.

This problem usually results in a panic inside SampleRecord#DecodeFrom (which is also missing a nil check when swapping Events due to different StreamID).

My solution is just to always copy memory from the ring-buffer into a slice owned by Event. This can also cause problems on its own as the record returned by Read(Raw)Record will be overwritten by the next call.

Issue 2 

`SampleRecord#DecodeFrom` swaps the current Event when the received StreamID doesn't match the current event (another ev is using this Event as output).  This needs a nil check in the case we're reading a malformed event (can be caused by #1) or for some reason we're reading an old event for a StreamID that is not known anymore (I don't know if that's possible at all).

Issue 3

Missing bounds checks in `readRawRecordNonblock`.
