### PR TITLE
Check for non-empty event buffer on perfhup

### DIFF
--- a/record.go
+++ b/record.go
@@ -130,6 +130,9 @@ again:
 		if resp.perfhup {
 			// Saw POLLHUP on ev.perffd. See also the
 			// documentation for ErrDisabled.
+			if ev.readRawRecordNonblock(raw) {
+				return nil
+			}
 			return ErrDisabled
 		}
 		if !resp.perfready {


### PR DESCRIPTION
Previously, if poll returned HUP, we would immediately return ErrDisabled, but
this means we could miss events if there are events waiting in the buffer.

Fixes: #23