### PR TITLE
Bugfix: runtime.LockOSThread required for command

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -3,6 +3,7 @@ package perf
 import (
 	"fmt"
 	"os/exec"
+	"runtime"
 	"syscall"
 )
 
@@ -12,6 +13,11 @@ func command(cmd *exec.Cmd, setupCounters func() error) error {
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
+
+	// Required by docs of syscall.SysProcAttr.Ptrace.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	cmd.SysProcAttr.Ptrace = true
 
 	err := cmd.Start()


### PR DESCRIPTION
The ptrace API requires that you call it from the same thread, so starting the process must lock the thread until we're done with the ptrace API.

Doc ref: https://pkg.go.dev/syscall#SysProcAttr

Without this, if I use this in a tight loop, it hangs.