### PR TITLE
Rename module to github.com/acln0/perf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module acln.ro/perf
+module github.com/acln0/perf
 
 go 1.12
 


### PR DESCRIPTION
Unfortunately acln.ro appears to be unavailable or misconfigured.

Can we make the module available again?

Currently it's not possible to call up the docs on https://pkg.go.dev/github.com/acln0/perf for example, it gives a 404.